### PR TITLE
Reverted so that ha-card is the second element of the card

### DIFF
--- a/www/hasl-comb-card.js
+++ b/www/hasl-comb-card.js
@@ -1,7 +1,7 @@
 class HASLCombCard extends HTMLElement {
     set hass(hass) {
         if (!this.content) {
-            const card = document.createElement('hasl-comb-card');
+            const card = document.createElement('ha-card');
             this.content = document.createElement('div');     
             card.appendChild(this.content);
             this.appendChild(card);


### PR DESCRIPTION
Second element of the card should be ha-card else hasl-comb-card comes twice and conflicts with the css styling in some cases.