### PR TITLE
Fixed bug where no departures were returned if no lines specified

### DIFF
--- a/custom_components/hasl/sensor.py
+++ b/custom_components/hasl/sensor.py
@@ -726,7 +726,7 @@ class SLDeparturesSensor(Entity):
                     icon = iconswitcher.get(traffictype, 'mdi:train-car')
                     if int(self._direction) == 0 or int(direction) \
                             == int(self._direction):
-                        if self._lines is None or linenumber \
+                        if self._lines == [] or linenumber \
                                 in self._lines:
                             diff = self.parseDepartureTime(displaytime)
                             if diff < self._timewindow:


### PR DESCRIPTION
Lines was set to default "[]" but comparison was done against "None"