### PR TITLE
Fixed default lines

### DIFF
--- a/custom_components/hasl/sensor.py
+++ b/custom_components/hasl/sensor.py
@@ -726,7 +726,7 @@ class SLDeparturesSensor(Entity):
                     icon = iconswitcher.get(traffictype, 'mdi:train-car')
                     if int(self._direction) == 0 or int(direction) \
                             == int(self._direction):
-                        if self._lines is None or linenumber \
+                        if len(self._lines) == 0 or linenumber \
                                 in self._lines:
                             diff = self.parseDepartureTime(displaytime)
                             if diff < self._timewindow:


### PR DESCRIPTION
The default value of the `lines` config is `[]`, not `None`.
This, in practice, makes the `lines` config mandatory.
https://github.com/DSorlov/hasl-platform/blob/7e2ce7e30d758cc39089dcb6bf54dddd8c3ac105/custom_components/hasl/sensor.py#L83

This PR fixes this problem.
